### PR TITLE
fix: restore runner_name placeholder after kustomize render

### DIFF
--- a/gha-runner-scale-set.yaml
+++ b/gha-runner-scale-set.yaml
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/version: 0.14.1
     helm.sh/chart: gha-rs-0.14.1
     runners.opzkit.io/version: ${version}
-  name: ${runner-name}-gha-rs-no-permission
+  name: ${runner_name}-gha-rs-no-permission
   namespace: ${namespace}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -130,7 +130,7 @@ metadata:
   annotations:
     actions.github.com/cleanup-manager-role-binding: ${runner_name}-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: ${runner_name}-gha-rs-manager
-    actions.github.com/cleanup-no-permission-service-account-name: ${runner-name}-gha-rs-no-permission
+    actions.github.com/cleanup-no-permission-service-account-name: ${runner_name}-gha-rs-no-permission
     actions.github.com/values-hash: 3d1ebb7445f77b17b5fe7b93f8e0a3244a0c36094c1127c072209eff1b5c462
   labels:
     actions.github.com/scale-set-name: ${runner_name}
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/version: 0.14.1
     helm.sh/chart: gha-rs-0.14.1
     runners.opzkit.io/version: ${version}
-  name: ${runner-name}
+  name: ${runner_name}
   namespace: ${namespace}
 spec:
   githubConfigSecret: ${github_config_secret}
@@ -212,7 +212,7 @@ spec:
         - mountPath: /home/runner/externals
           name: dind-externals
       restartPolicy: Never
-      serviceAccountName: ${runner-name}-gha-rs-no-permission
+      serviceAccountName: ${runner_name}-gha-rs-no-permission
       volumes:
       - emptyDir: {}
         name: dind-sock

--- a/gha-runner-scale-set.yaml
+++ b/gha-runner-scale-set.yaml
@@ -9,16 +9,16 @@ metadata:
   finalizers:
   - actions.github.com/cleanup-protection
   labels:
-    actions.github.com/scale-set-name: ${runner_name}
+    actions.github.com/scale-set-name: ${name}
     actions.github.com/scale-set-namespace: ${namespace}
-    app.kubernetes.io/instance: ${runner_name}
+    app.kubernetes.io/instance: ${name}
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: ${runner_name}
+    app.kubernetes.io/name: ${name}
     app.kubernetes.io/part-of: gha-rs
     app.kubernetes.io/version: 0.14.1
     helm.sh/chart: gha-rs-0.14.1
     runners.opzkit.io/version: ${version}
-  name: ${runner_name}-gha-rs-no-permission
+  name: ${name}-gha-rs-no-permission
   namespace: ${namespace}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,17 +27,17 @@ metadata:
   finalizers:
   - actions.github.com/cleanup-protection
   labels:
-    actions.github.com/scale-set-name: ${runner_name}
+    actions.github.com/scale-set-name: ${name}
     actions.github.com/scale-set-namespace: ${namespace}
     app.kubernetes.io/component: manager-role
-    app.kubernetes.io/instance: ${runner_name}
+    app.kubernetes.io/instance: ${name}
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: ${runner_name}
+    app.kubernetes.io/name: ${name}
     app.kubernetes.io/part-of: gha-rs
     app.kubernetes.io/version: 0.14.1
     helm.sh/chart: gha-rs-0.14.1
     runners.opzkit.io/version: ${version}
-  name: ${runner_name}-gha-rs-manager
+  name: ${name}-gha-rs-manager
   namespace: ${namespace}
 rules:
 - apiGroups:
@@ -103,22 +103,22 @@ metadata:
   finalizers:
   - actions.github.com/cleanup-protection
   labels:
-    actions.github.com/scale-set-name: ${runner_name}
+    actions.github.com/scale-set-name: ${name}
     actions.github.com/scale-set-namespace: ${namespace}
     app.kubernetes.io/component: manager-role-binding
-    app.kubernetes.io/instance: ${runner_name}
+    app.kubernetes.io/instance: ${name}
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: ${runner_name}
+    app.kubernetes.io/name: ${name}
     app.kubernetes.io/part-of: gha-rs
     app.kubernetes.io/version: 0.14.1
     helm.sh/chart: gha-rs-0.14.1
     runners.opzkit.io/version: ${version}
-  name: ${runner_name}-gha-rs-manager
+  name: ${name}-gha-rs-manager
   namespace: ${namespace}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: ${runner_name}-gha-rs-manager
+  name: ${name}-gha-rs-manager
 subjects:
 - kind: ServiceAccount
   name: arc-gha-rs-controller
@@ -128,22 +128,22 @@ apiVersion: actions.github.com/v1alpha1
 kind: AutoscalingRunnerSet
 metadata:
   annotations:
-    actions.github.com/cleanup-manager-role-binding: ${runner_name}-gha-rs-manager
-    actions.github.com/cleanup-manager-role-name: ${runner_name}-gha-rs-manager
-    actions.github.com/cleanup-no-permission-service-account-name: ${runner_name}-gha-rs-no-permission
-    actions.github.com/values-hash: 3d1ebb7445f77b17b5fe7b93f8e0a3244a0c36094c1127c072209eff1b5c462
+    actions.github.com/cleanup-manager-role-binding: ${name}-gha-rs-manager
+    actions.github.com/cleanup-manager-role-name: ${name}-gha-rs-manager
+    actions.github.com/cleanup-no-permission-service-account-name: ${name}-gha-rs-no-permission
+    actions.github.com/values-hash: 87e627988829e0ebf8d11dae3c5b6ab43f2599a937c265cc6be089580967361
   labels:
-    actions.github.com/scale-set-name: ${runner_name}
+    actions.github.com/scale-set-name: ${name}
     actions.github.com/scale-set-namespace: ${namespace}
     app.kubernetes.io/component: autoscaling-runner-set
-    app.kubernetes.io/instance: ${runner_name}
+    app.kubernetes.io/instance: ${name}
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: ${runner_name}
+    app.kubernetes.io/name: ${name}
     app.kubernetes.io/part-of: gha-rs
     app.kubernetes.io/version: 0.14.1
     helm.sh/chart: gha-rs-0.14.1
     runners.opzkit.io/version: ${version}
-  name: ${runner_name}
+  name: ${name}
   namespace: ${namespace}
 spec:
   githubConfigSecret: ${github_config_secret}
@@ -156,8 +156,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
-  runnerGroup: ${runner_group}
-  runnerScaleSetName: ${runner_name}
+  runnerGroup: ${group}
+  runnerScaleSetName: ${name}
   template:
     spec:
       containers:
@@ -212,7 +212,7 @@ spec:
         - mountPath: /home/runner/externals
           name: dind-externals
       restartPolicy: Never
-      serviceAccountName: ${runner_name}-gha-rs-no-permission
+      serviceAccountName: ${name}-gha-rs-no-permission
       volumes:
       - emptyDir: {}
         name: dind-sock

--- a/gha-runner-scale-set/values.yaml
+++ b/gha-runner-scale-set/values.yaml
@@ -5,8 +5,8 @@ minRunners: ${min_runners}
 controllerServiceAccount:
   name: "arc-gha-rs-controller"
   namespace: "arc-systems"
-runnerScaleSetName: ${runner_name}
-runnerGroup: ${runner_group}
+runnerScaleSetName: ${name}
+runnerGroup: ${group}
 containerMode:
   type: "dind"
 labels:

--- a/locals.tf
+++ b/locals.tf
@@ -5,8 +5,8 @@ locals {
     github_config_url    = var.github_config_url
     max_runners          = var.max_runners
     min_runners          = var.min_runners
-    runner_group         = var.runner_group
-    runner_name          = var.runner_name
+    group                = var.runner_group
+    name                 = var.runner_name
     namespace            = var.namespace
     version              = local.version
   })

--- a/updatecli/updatecli.d/terraform-aws-k8s-addons-github-runners.yaml
+++ b/updatecli/updatecli.d/terraform-aws-k8s-addons-github-runners.yaml
@@ -22,7 +22,7 @@ targets:
     dependsonchange: true
     disablesourceinput: true
     spec:
-      command: "rm -rf gha-runner-scale-set/charts && kubectl kustomize . -o gha-runner-scale-set.yaml --enable-helm"
+      command: "rm -rf gha-runner-scale-set/charts && kubectl kustomize . -o gha-runner-scale-set.yaml --enable-helm && sed -i 's/\\${runner-name}/${runner_name}/g' gha-runner-scale-set.yaml"
       changedif:
         kind: file/checksum
         spec:

--- a/updatecli/updatecli.d/terraform-aws-k8s-addons-github-runners.yaml
+++ b/updatecli/updatecli.d/terraform-aws-k8s-addons-github-runners.yaml
@@ -22,7 +22,7 @@ targets:
     dependsonchange: true
     disablesourceinput: true
     spec:
-      command: "rm -rf gha-runner-scale-set/charts && kubectl kustomize . -o gha-runner-scale-set.yaml --enable-helm && sed -i 's/\\${runner-name}/${runner_name}/g' gha-runner-scale-set.yaml"
+      command: "rm -rf gha-runner-scale-set/charts && kubectl kustomize . -o gha-runner-scale-set.yaml --enable-helm"
       changedif:
         kind: file/checksum
         spec:


### PR DESCRIPTION
## Summary
- Chart 0.14.1 helper renders `runnerScaleSetName` hyphenated in four spots, producing `${runner-name}` which Terraform's `templatefile()` rejects (hyphens not allowed in var names). This broke every Build run since #149.
- Patch the rendered `gha-runner-scale-set.yaml` back to `${runner_name}`.
- Add a `sed` post-process to the updatecli kubectl target so the next chart bump doesn't reintroduce the typo.

## Test plan
- [x] `make examples` succeeds locally for both `basic` and `overrides`.
- [ ] CI examples job passes after merge.